### PR TITLE
Allow file downloads to follow redirects.

### DIFF
--- a/common/fileprovider.cpp
+++ b/common/fileprovider.cpp
@@ -116,6 +116,7 @@ bool FileProvider::get(const QUrl &url, QString &target)
         qDebug("Downloading '%s'", url.toEncoded().constData());
 
         QNetworkAccessManager manager;
+        manager.setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
         QNetworkRequest request(url);
         QNetworkReply *job = manager.get(request);
 


### PR DESCRIPTION
Enable no-less-safe redirect policy to allow file downloads that require to follow a redirect.
Currently schema downloads have a tendency to fail if the target server employs a redirect to the final file.